### PR TITLE
Add structured bilingual docs

### DIFF
--- a/README.it.md
+++ b/README.it.md
@@ -2,6 +2,7 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
 > 🇬🇧 [English version](README.md)
+> 📚 [Documentazione estesa](docs/it/index.md)
 
 <p align="center">
   <img src="./front/html/img/logo.svg" alt="Ansvil logo" width="150">
@@ -118,56 +119,6 @@ Puoi modificare tutte le credenziali iniziali tramite il file `.env`.
 
 ---
 
-## Hook di inizializzazione (`entrypoint.d/`)
-
-Ansvil supporta **hook modulari** eseguibili in fasi chiave del ciclo di vita dei container.
-
-### Struttura delle directory
-
-```
-/entrypoint.d/
-├── root/   → script eseguiti come utente root
-└── user/   → script eseguiti come utente applicativo (es. ansvil)
-```
-
-### Eventi disponibili
-
-| Evento  | Momento                                       | Descrizione                              |
-| ------- | --------------------------------------------- | ---------------------------------------- |
-| `init`  | Solo al primo avvio (creazione del container) | Setup iniziale, installazioni, bootstrap |
-| `start` | A ogni avvio del container                    | Post-avvio, healthcheck, trigger custom  |
-| `exit`  | Alla chiusura (SIGTERM/SIGINT)                | Pulizia finale, salvataggi, notifiche    |
-
-### Convenzione di naming
-
-```
-NN-<evento>-<descrizione>.sh
-```
-
-Esempi:
-
-* `10-init-install-ansible.sh`
-* `20-start-healthcheck.sh`
-* `99-exit-cleanup.sh`
-
-Gli script sono ordinati ed eseguiti in ordine crescente, per `root` e `user` separatamente.
-
-### Inizializzazione automatica
-
-Se le directory `entrypoint.d/root/` o `entrypoint.d/user/` mancano, Ansvil copierà un template base da `/template/entrypoint.d/`.
-Personalizzabile e montabile su `/data`.
-
-### Esempio: hook user/init
-
-```bash
-#!/bin/bash
-echo ">> [user/init] Installazione iniziale delle collection Ansible"
-
-# ansible-galaxy collection install community.general
-# pip install netaddr passlib
-```
-
----
 
 ## Licenza e componenti open-source
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
 > 🇮🇹 [Versione italiana](README.it.md)
+> 📚 [Full documentation](docs/en/index.md)
 
 <p align="center">
   <img src="./front/html/img/logo.svg" alt="Ansvil logo" width="150">
@@ -118,56 +119,6 @@ You can change all initial credentials via the `.env` file.
 
 ---
 
-## Initialization hooks (`entrypoint.d/`)
-
-Ansvil supports **modular hooks** that run at key points in the container lifecycle.
-
-### Directory structure
-
-```
-/entrypoint.d/
-├── root/   → scripts run as root
-└── user/   → scripts run as app user (e.g. ansvil)
-```
-
-### Available events
-
-| Event   | When it runs                           | Description                                |
-| ------- | -------------------------------------- | ------------------------------------------ |
-| `init`  | First launch only (container creation) | Initial setup, installation, bootstrap     |
-| `start` | On every container start               | Post-start, health checks, custom triggers |
-| `exit`  | On shutdown (SIGTERM/SIGINT)           | Final cleanup, save tasks, notifications   |
-
-### Naming convention
-
-```
-NN-<event>-<description>.sh
-```
-
-Examples:
-
-* `10-init-install-ansible.sh`
-* `20-start-healthcheck.sh`
-* `99-exit-cleanup.sh`
-
-Scripts are sorted and executed in ascending order, separately for `root` and `user`.
-
-### Automatic initialization
-
-If the `entrypoint.d/root/` or `entrypoint.d/user/` directories are missing, Ansvil will copy a default template from `/template/entrypoint.d/`.
-This is customizable and can be mounted at `/data`.
-
-### Example: user/init hook
-
-```bash
-#!/bin/bash
-echo ">> [user/init] Initial installation of Ansible collections"
-
-# ansible-galaxy collection install community.general
-# pip install netaddr passlib
-```
-
----
 
 ## License and open-source components
 

--- a/docs/en/access.md
+++ b/docs/en/access.md
@@ -1,0 +1,31 @@
+> 🇮🇹 [Versione italiana](../it/access.md)
+
+# Access and credentials
+
+Once Ansvil is up and running, you can access the web interface via browser:
+
+[https://127.0.0.1](https://127.0.0.1) or [https://localhost](https://localhost)
+
+A **welcome page** will appear with direct links to:
+
+* **Code-Server**
+* **Semaphore UI**
+
+## Access from other devices (LAN)
+
+If the host is properly configured (hostname, firewall, local DNS), you can access it from your local network:
+
+* via **local hostname** (e.g. `https://ansvil.local`)
+* or via **private IP** (e.g. `https://192.168.1.42`)
+
+In both cases, **as long as port `443` is reachable**, you're good to go.
+No need to expose ports `8080` or `3000` directly.
+
+## Default credentials
+
+| Service          | User    | Password                   |
+| ---------------- | ------- | -------------------------- |
+| **Code-Server**  |         | `ansvil` *(password only)* |
+| **Semaphore UI** | `admin` | `ansvil`                   |
+
+You can change all initial credentials via the `.env` file.

--- a/docs/en/deployment.md
+++ b/docs/en/deployment.md
@@ -1,0 +1,24 @@
+> 🇮🇹 [Versione italiana](../it/deployment.md)
+
+# Deployment and ports
+
+Ansvil uses `network_mode: host` to ensure that **Ansible** can interact directly with the host's network, simplifying communication with local devices.
+
+## Warning
+
+- **Dedicated host recommended** – Avoid conflicts with other services listening on the same ports.
+- **Firewall is a must** – Expose only strictly necessary ports.
+- **Time sync (NTP)** – Crucial for TLS, logging, and scheduling.
+
+## Ports used
+
+| Port  | Purpose                     | Notes |
+|-------|-----------------------------|----------------------------------------------|
+| `80`  | HTTP                        | Automatically redirects to HTTPS (`443`)      |
+| `443` | HTTPS (reverse proxy)       | **Only port to expose for web access**        |
+| `8080`| Code-Server (internal)      | Accessible only via reverse proxy            |
+| `3000`| Semaphore UI (internal)     | Accessible only via reverse proxy            |
+| `3306`| MariaDB (internal)          | Accessible only from containers              |
+
+**Only expose port `443`** externally.
+All other ports are used **internally within the container** and managed by the integrated reverse proxy (Nginx-based).

--- a/docs/en/hooks.md
+++ b/docs/en/hooks.md
@@ -1,0 +1,50 @@
+> 🇮🇹 [Versione italiana](../it/hooks.md)
+
+# Initialization hooks (`entrypoint.d/`)
+
+Ansvil supports **modular hooks** that run at key points in the container lifecycle.
+
+## Directory structure
+
+```
+/entrypoint.d/
+├── root/   → scripts run as root
+└── user/   → scripts run as app user (e.g. ansvil)
+```
+
+## Available events
+
+| Event   | When it runs                           | Description |
+| ------- | -------------------------------------- | --------------------------- |
+| `init`  | First launch only (container creation) | Initial setup, installation, bootstrap |
+| `start` | On every container start               | Post-start, health checks, custom triggers |
+| `exit`  | On shutdown (SIGTERM/SIGINT)           | Final cleanup, save tasks, notifications |
+
+## Naming convention
+
+```
+NN-<event>-<description>.sh
+```
+
+Examples:
+
+* `10-init-install-ansible.sh`
+* `20-start-healthcheck.sh`
+* `99-exit-cleanup.sh`
+
+Scripts are sorted and executed in ascending order, separately for `root` and `user`.
+
+## Automatic initialization
+
+If the `entrypoint.d/root/` or `entrypoint.d/user/` directories are missing, Ansvil will copy a default template from `/template/entrypoint.d/`.
+This is customizable and can be mounted at `/data`.
+
+## Example: user/init hook
+
+```bash
+#!/bin/bash
+echo ">> [user/init] Initial installation of Ansible collections"
+
+# ansible-galaxy collection install community.general
+# pip install netaddr passlib
+```

--- a/docs/en/index.md
+++ b/docs/en/index.md
@@ -1,0 +1,27 @@
+[![Version](https://img.shields.io/badge/version-v0.1.7--beta-blue)](#)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+
+> 🇮🇹 [Versione italiana](../it/index.md)
+
+<p align="center">
+  <img src="../../front/html/img/logo.svg" alt="Ansvil logo" width="150">
+</p>
+
+# Ansvil documentation
+
+Ansvil is a lightweight and modular Docker container based on **AlmaLinux**, designed to provide a complete, stable, and portable environment for **Ansible** automation.
+
+## Project contents
+
+- **AlmaLinux 9.x** – a RHEL-compatible, stable and secure base
+- **Ansible** – the core automation engine
+- **Code-Server** – browser-accessible Visual Studio Code
+- **Semaphore UI** – frontend to manage Ansible tasks
+
+## Sections
+
+- [Quick start](quick-start.md)
+- [Deployment and ports](deployment.md)
+- [Access and credentials](access.md)
+- [Initialization hooks](hooks.md)
+- [License](license.md)

--- a/docs/en/license.md
+++ b/docs/en/license.md
@@ -1,0 +1,16 @@
+> 🇮🇹 [Versione italiana](../it/license.md)
+
+# License and open-source components
+
+Ansvil is released under the [MIT](../../LICENSE) license.
+It uses or integrates the following open-source components:
+
+| Component    | License    |
+| ------------ | ---------- |
+| Ansible      | GNU GPL v3 |
+| Code-Server  | MIT        |
+| Semaphore UI | MIT        |
+| MariaDB      | GNU GPL v2 |
+| Nginx        | BSD-like   |
+
+Check official licenses for compliance, especially in enterprise environments or when redistributing.

--- a/docs/en/quick-start.md
+++ b/docs/en/quick-start.md
@@ -1,0 +1,27 @@
+> 🇮🇹 [Versione italiana](../it/quick-start.md)
+
+# Quick start
+
+### `make` method (recommended)
+
+```bash
+git clone https://github.com/lineadicomando/ansvil.git
+cd ansvil
+make init     # creates .env file if missing
+make up       # starts services in background
+```
+
+For more available commands:
+
+```bash
+make help
+```
+
+### Manual method (without `make`)
+
+```bash
+git clone https://github.com/lineadicomando/ansvil.git
+cd ansvil
+cp .env.example .env  # configure environment variables
+docker compose up -d
+````

--- a/docs/it/access.md
+++ b/docs/it/access.md
@@ -1,0 +1,31 @@
+> 🇬🇧 [English version](../en/access.md)
+
+# Accesso e credenziali
+
+Una volta avviato Ansvil, puoi accedere all'interfaccia web tramite browser:
+
+https://127.0.0.1 oppure https://localhost
+
+Comparirà una **pagina di benvenuto** con collegamenti diretti a:
+
+* **Code-Server**
+* **Semaphore UI**
+
+## Accesso da altri dispositivi (LAN)
+
+Se l'host è configurato correttamente (hostname, firewall, DNS locale), puoi accedere anche dalla rete locale:
+
+* tramite **hostname locale** (es. `https://ansvil.local`)
+* oppure con **IP privato** (es. `https://192.168.1.42`)
+
+In entrambi i casi, **basta che la porta `443` sia raggiungibile**.
+Non è necessario esporre direttamente le porte `8080` o `3000`.
+
+## Credenziali predefinite
+
+| Servizio         | Utente       | Password                   |
+| ---------------- | ------------ | -------------------------- |
+| **Code-Server**  |              | `ansvil` *(solo password)* |
+| **Semaphore UI** | `admin`      | `ansvil`                   |
+
+Puoi modificare tutte le credenziali iniziali tramite il file `.env`.

--- a/docs/it/deployment.md
+++ b/docs/it/deployment.md
@@ -1,0 +1,24 @@
+> 🇬🇧 [English version](../en/deployment.md)
+
+# Deployment e porte
+
+Ansvil utilizza `network_mode: host` per garantire che **Ansible** possa interagire direttamente con la rete dell'host, semplificando la comunicazione con dispositivi locali.
+
+## Attenzione
+
+- **Host dedicato consigliato** – Evita conflitti con altri servizi in ascolto sulle stesse porte.
+- **Firewall obbligatorio** – Esponi solo le porte strettamente necessarie.
+- **Sincronizzazione dell'orario (NTP)** – Fondamentale per TLS, logging, pianificazioni.
+
+## Porte utilizzate
+
+| Porta | Uso                        | Note |
+|-------|-----------------------------|-------------------------------------------|
+| `80`  | HTTP                        | Redirect automatico verso HTTPS (`443`)   |
+| `443` | HTTPS (reverse proxy)       | **Unica porta da esporre per accesso web** |
+| `8080`| Code-Server (interno)       | Accessibile solo tramite reverse proxy    |
+| `3000`| Semaphore UI (interno)      | Accessibile solo tramite reverse proxy    |
+| `3306`| MariaDB (interno)           | Accessibile solo dai container            |
+
+**Esporre solo la porta `443`** all'esterno.
+Tutte le altre porte sono utilizzate **solo all'interno del container** e gestite dal reverse proxy integrato (basato su Nginx).

--- a/docs/it/hooks.md
+++ b/docs/it/hooks.md
@@ -1,0 +1,50 @@
+> 🇬🇧 [English version](../en/hooks.md)
+
+# Hook di inizializzazione (`entrypoint.d/`)
+
+Ansvil supporta **hook modulari** eseguibili in fasi chiave del ciclo di vita dei container.
+
+## Struttura delle directory
+
+```
+/entrypoint.d/
+├── root/   → script eseguiti come utente root
+└── user/   → script eseguiti come utente applicativo (es. ansvil)
+```
+
+## Eventi disponibili
+
+| Evento  | Momento                                       | Descrizione |
+| ------- | --------------------------------------------- | ---------------------------- |
+| `init`  | Solo al primo avvio (creazione del container) | Setup iniziale, installazioni, bootstrap |
+| `start` | A ogni avvio del container                    | Post-avvio, healthcheck, trigger custom |
+| `exit`  | Alla chiusura (SIGTERM/SIGINT)                | Pulizia finale, salvataggi, notifiche |
+
+## Convenzione di naming
+
+```
+NN-<evento>-<descrizione>.sh
+```
+
+Esempi:
+
+* `10-init-install-ansible.sh`
+* `20-start-healthcheck.sh`
+* `99-exit-cleanup.sh`
+
+Gli script sono ordinati ed eseguiti in ordine crescente, per `root` e `user` separatamente.
+
+## Inizializzazione automatica
+
+Se le directory `entrypoint.d/root/` o `entrypoint.d/user/` mancano, Ansvil copierà un template base da `/template/entrypoint.d/`.
+Personalizzabile e montabile su `/data`.
+
+## Esempio: hook user/init
+
+```bash
+#!/bin/bash
+echo ">> [user/init] Installazione iniziale delle collection Ansible"
+
+# ansible-galaxy collection install community.general
+# pip install netaddr passlib
+```

--- a/docs/it/index.md
+++ b/docs/it/index.md
@@ -1,0 +1,27 @@
+[![Version](https://img.shields.io/badge/version-v0.1.7--beta-blue)](#)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+
+> 🇬🇧 [English version](../en/index.md)
+
+<p align="center">
+  <img src="../../front/html/img/logo.svg" alt="Ansvil logo" width="150">
+</p>
+
+# Documentazione di Ansvil
+
+Ansvil è un container Docker leggero e modulare basato su **AlmaLinux**, progettato per offrire un ambiente completo, stabile e portatile per l'automazione con **Ansible**.
+
+## Contenuto del progetto
+
+- **AlmaLinux 9.x** – base compatibile con RHEL, stabile e sicura
+- **Ansible** – cuore del sistema di automazione
+- **Code-Server** – Visual Studio Code accessibile via browser
+- **Semaphore UI** – frontend per il controllo dei task Ansible
+
+## Sezioni
+
+- [Avvio rapido](quick-start.md)
+- [Deployment e porte](deployment.md)
+- [Accesso e credenziali](access.md)
+- [Hook di inizializzazione](hooks.md)
+- [Licenza](license.md)

--- a/docs/it/license.md
+++ b/docs/it/license.md
@@ -1,0 +1,16 @@
+> 🇬🇧 [English version](../en/license.md)
+
+# Licenza e componenti open-source
+
+Ansvil è distribuito sotto licenza [MIT](../../LICENSE).
+Utilizza o integra i seguenti componenti open-source:
+
+| Componente   | Licenza    |
+| ------------ | ---------- |
+| Ansible      | GNU GPL v3 |
+| Code-Server  | MIT        |
+| Semaphore UI | MIT        |
+| MariaDB      | GNU GPL v2 |
+| Nginx        | BSD-like   |
+
+Verifica le licenze ufficiali per un uso conforme, soprattutto in ambienti aziendali o in caso di ridistribuzione.

--- a/docs/it/quick-start.md
+++ b/docs/it/quick-start.md
@@ -1,0 +1,27 @@
+> 🇬🇧 [English version](../en/quick-start.md)
+
+# Avvio rapido
+
+### Metodo con `make` (consigliato)
+
+```bash
+git clone https://github.com/lineadicomando/ansvil.git
+cd ansvil
+make init     # crea il file .env se non esiste
+make up       # avvia i servizi in background
+```
+
+Per altri comandi disponibili:
+
+```bash
+make help
+```
+
+### Metodo manuale (senza `make`)
+
+```bash
+git clone https://github.com/lineadicomando/ansvil.git
+cd ansvil
+cp .env.example .env  # configura le variabili d'ambiente
+docker compose up -d
+````


### PR DESCRIPTION
## Summary
- remove initialization hook section from README files
- redesign docs folder with multi-file structure in both languages

## Testing
- `make help`


------
https://chatgpt.com/codex/tasks/task_e_6842b8a975cc8332b7132f7f7db0b0f4