### PR TITLE
Add prerequisites docs

### DIFF
--- a/docs/en/index.md
+++ b/docs/en/index.md
@@ -20,8 +20,10 @@ Ansvil is a lightweight and modular Docker container based on **AlmaLinux**, des
 
 ## Sections
 
+- [Prerequisites](prerequisites.md)
 - [Quick start](quick-start.md)
 - [Deployment and ports](deployment.md)
 - [Access and credentials](access.md)
 - [Initialization hooks](hooks.md)
+- [Makefile commands](makefile.md)
 - [License](license.md)

--- a/docs/en/makefile.md
+++ b/docs/en/makefile.md
@@ -1,0 +1,29 @@
+> 🇮🇹 [Versione italiana](../it/makefile.md)
+
+# Makefile commands
+
+The Makefile provides handy shortcuts to manage the container. Run `make help` to see the available targets.
+
+| Command | Description |
+| ------- | ----------- |
+| `check-env` | Ensure that the `.env` file exists and that root or sudo is available |
+| `ps` | Show the status of Docker Compose services |
+| `status` | Alias for `ps` |
+| `up` | Start Docker Compose services in background |
+| `down` | Stop and remove Docker Compose services |
+| `start` | Start existing Docker Compose containers |
+| `stop` | Stop running containers without removing them |
+| `restart` | Restart Docker Compose services (full rebuild) |
+| `restart-soft` | Restart services without recreating containers |
+| `logs` | Show logs from all services |
+| `logs-<service>` | Show logs from a specific service |
+| `pull` | Pull latest Docker images |
+| `update` | Pull and restart all services |
+| `init` | Initialize `.env` from `.env.example` |
+| `shell` | Enter the container shell as the application user |
+| `chcodpw` | Change Code-Server password |
+| `chdempw` | Change Semaphore UI password |
+| `root-shell` | Enter the root shell of the `core` container |
+| `help` | Show available commands |
+
+Additional targets can be defined in a local `Makefile.local` and will appear at the end of `make help`.

--- a/docs/en/prerequisites.md
+++ b/docs/en/prerequisites.md
@@ -1,0 +1,63 @@
+🇮🇹 [Versione italiana](../it/prerequisiti.md)
+
+# Prerequisites
+
+Ansvil relies on containers to run its services. You need Docker (with the Compose plugin) or Podman (with `podman-compose` and `podman-docker`) and `make` installed on your host.
+
+This guide assumes a minimal installation of AlmaLinux/Fedora or Debian.
+
+## Install Docker on AlmaLinux or Fedora
+
+1. Remove any existing Docker packages:
+   ```bash
+   sudo dnf remove docker docker-engine docker.io containerd runc
+   ```
+2. Enable the official Docker repository:
+   ```bash
+   sudo dnf install -y dnf-plugins-core
+   sudo dnf config-manager --add-repo https://download.docker.com/linux/$(. /etc/os-release && echo $ID)/docker-ce.repo
+   ```
+3. Install Docker Engine and the Compose plugin together with `make`:
+   ```bash
+   sudo dnf install docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin make
+   ```
+4. Enable and start the service:
+   ```bash
+   sudo systemctl enable --now docker
+   ```
+
+You can install Podman as an alternative:
+```bash
+sudo dnf install podman podman-compose podman-docker
+```
+
+## Install Docker on Debian
+
+1. Remove any existing Docker packages:
+   ```bash
+   sudo apt-get remove docker docker-engine docker.io containerd runc
+   ```
+2. Add the official Docker repository:
+   ```bash
+   sudo apt-get update
+   sudo apt-get install -y ca-certificates curl gnupg
+   sudo install -m 0755 -d /etc/apt/keyrings
+   curl -fsSL https://download.docker.com/linux/$(. /etc/os-release && echo $ID)/gpg | sudo gpg --dearmor -o /etc/apt/keyrings/docker.gpg
+   echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/$(. /etc/os-release && echo $ID) $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
+   sudo apt-get update
+   ```
+3. Install Docker Engine, the Compose plugin and `make`:
+   ```bash
+   sudo apt-get install docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin make
+   ```
+4. Start the service:
+   ```bash
+   sudo systemctl enable --now docker
+   ```
+
+For Podman on Debian:
+```bash
+sudo apt-get install podman podman-compose podman-docker
+```
+
+After installing Docker or Podman, `make up` will start Ansvil.

--- a/docs/it/index.md
+++ b/docs/it/index.md
@@ -20,8 +20,10 @@ Ansvil è un container Docker leggero e modulare basato su **AlmaLinux**, proget
 
 ## Sezioni
 
+- [Prerequisiti](prerequisiti.md)
 - [Avvio rapido](quick-start.md)
 - [Deployment e porte](deployment.md)
 - [Accesso e credenziali](access.md)
 - [Hook di inizializzazione](hooks.md)
+- [Comandi del Makefile](makefile.md)
 - [Licenza](license.md)

--- a/docs/it/makefile.md
+++ b/docs/it/makefile.md
@@ -1,0 +1,29 @@
+> 🇬🇧 [English version](../en/makefile.md)
+
+# Comandi del Makefile
+
+Il Makefile offre scorciatoie per gestire il container. Esegui `make help` per vedere i target disponibili.
+
+| Comando | Descrizione |
+| ------- | ----------- |
+| `check-env` | Verifica l'esistenza del file `.env` e la disponibilità di root o sudo |
+| `ps` | Mostra lo stato dei servizi Docker Compose |
+| `status` | Alias di `ps` |
+| `up` | Avvia i servizi Docker Compose in background |
+| `down` | Ferma e rimuove i servizi Docker Compose |
+| `start` | Avvia i container esistenti |
+| `stop` | Ferma i container senza rimuoverli |
+| `restart` | Riavvia i servizi Docker Compose (ricostruzione completa) |
+| `restart-soft` | Riavvia i servizi senza ricreare i container |
+| `logs` | Mostra i log di tutti i servizi |
+| `logs-<servizio>` | Mostra i log di un servizio specifico |
+| `pull` | Scarica le ultime immagini Docker |
+| `update` | Scarica e riavvia tutti i servizi |
+| `init` | Inizializza `.env` da `.env.example` |
+| `shell` | Entra nella shell del container come utente applicativo |
+| `chcodpw` | Cambia la password di Code-Server |
+| `chdempw` | Cambia la password di Semaphore UI |
+| `root-shell` | Entra nella shell root del container `core` |
+| `help` | Mostra i comandi disponibili |
+
+Ulteriori target possono essere definiti in un `Makefile.local` e compariranno alla fine di `make help`.

--- a/docs/it/prerequisiti.md
+++ b/docs/it/prerequisiti.md
@@ -1,0 +1,63 @@
+🇬🇧 [English version](../en/prerequisites.md)
+
+# Prerequisiti
+
+Ansvil utilizza container per eseguire i suoi servizi. È necessario installare Docker (con il plugin Compose) oppure Podman (con `podman-compose` e `podman-docker`) e `make` sull'host.
+
+Questa guida è pensata per una installazione minimale di AlmaLinux/Fedora o Debian.
+
+## Installare Docker su AlmaLinux o Fedora
+
+1. Rimuovere eventuali pacchetti Docker già presenti:
+   ```bash
+   sudo dnf remove docker docker-engine docker.io containerd runc
+   ```
+2. Abilitare il repository ufficiale di Docker:
+   ```bash
+   sudo dnf install -y dnf-plugins-core
+   sudo dnf config-manager --add-repo https://download.docker.com/linux/$(. /etc/os-release && echo $ID)/docker-ce.repo
+   ```
+3. Installare Docker Engine e il plugin Compose insieme a `make`:
+   ```bash
+   sudo dnf install docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin make
+   ```
+4. Abilitare e avviare il servizio:
+   ```bash
+   sudo systemctl enable --now docker
+   ```
+
+In alternativa si può installare Podman:
+```bash
+sudo dnf install podman podman-compose podman-docker
+```
+
+## Installare Docker su Debian
+
+1. Rimuovere eventuali versioni precedenti:
+   ```bash
+   sudo apt-get remove docker docker-engine docker.io containerd runc
+   ```
+2. Aggiungere il repository ufficiale:
+   ```bash
+   sudo apt-get update
+   sudo apt-get install -y ca-certificates curl gnupg
+   sudo install -m 0755 -d /etc/apt/keyrings
+   curl -fsSL https://download.docker.com/linux/$(. /etc/os-release && echo $ID)/gpg | sudo gpg --dearmor -o /etc/apt/keyrings/docker.gpg
+   echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/$(. /etc/os-release && echo $ID) $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
+   sudo apt-get update
+   ```
+3. Installare Docker Engine, il plugin Compose e `make`:
+   ```bash
+   sudo apt-get install docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin make
+   ```
+4. Avviare il servizio:
+   ```bash
+   sudo systemctl enable --now docker
+   ```
+
+Per installare Podman su Debian:
+```bash
+sudo apt-get install podman podman-compose podman-docker
+```
+
+Dopo l'installazione di Docker o Podman, `make up` avvierà Ansvil.


### PR DESCRIPTION
## Summary
- add new prerequisites section in English and Italian
- link the new docs from the documentation index

## Testing
- `make help > /tmp/make_help.txt && tail -n 10 /tmp/make_help.txt`


------
https://chatgpt.com/codex/tasks/task_e_6842bfac2a108332becd5d5e3ffde3f1